### PR TITLE
Cleanup and add support for CentOS 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,21 @@
+.vagrant
 *~
 *#
 .#*
 \#*#
 .*.sw[a-z]
 *.un~
-pkg/
-
-# Berkshelf
-.vagrant
-/cookbooks
-Berksfile.lock
 
 # Bundler
 Gemfile.lock
 bin/*
 .bundle/*
 
+# test kitchen
 .kitchen/
 .kitchen.local.yml
+
+# Chef
+Berksfile.lock
+.zero-knife.rb
+Policyfile.lock.json

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,15 +1,8 @@
 ---
 driver:
-  name: vagrant
-
-provisioner:
-  name: chef_solo
-
-platforms:
-  - name: ubuntu-14.04
-  - name: centos-7.1
+  flavor_ref: 'm1.medium'
 
 suites:
   - name: default
     run_list:
-    attributes:
+      - recipe[osl-letsencrypt-boulder-server]

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation --color

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,21 @@
+AllCops:
+  Include:
+    - '**/Berksfile'
+    - '**/Cheffile'
+  Exclude:
+    - 'metadata.rb'
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+
+Metrics/LineLength:
+  Max: 120
+
+Style/IfUnlessModifier:
+  MaxLineLength: 120
+
+Style/WhileUntilModifier:
+  MaxLineLength: 120
+
+Metrics/BlockLength:
+  Enabled: false

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source "https://supermarket.chef.io"
+source 'https://supermarket.chef.io'
 
 metadata

--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@
 This is a cookbook for provisioning [Boulder][], an
 [ACME-based][acme-spec] certificate authority, written in Go. The
 Boulder application is an official effort of [Let's Encrypt
-project][letsencrypt].
+project][letsencrypt]. This particular cookbook is a fork of
+[letsencrypt-boulder-server](https://github.com/patcon/chef-letsencrypt-boulder-server)
+for use at the OSUOSL.
 
 **Warning:** This cookbook was created for testing other cookbooks, not
 production purposes.
 
 ## Supported Platforms
 
-* Ubuntu 14.04
-* Centos 7
+* CentOS 6
+* CentOS 7
 
 ## Attributes
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,130 @@
-require 'stove/rake_task'
-Stove::RakeTask.new
+# Rake tasks
+
+require 'rake'
+
+require 'fileutils'
+require 'base64'
+require 'chef/encrypted_data_bag_item'
+require 'json'
+require 'openssl'
+
+snakeoil_file_path = 'test/integration/data_bags/certificates/snakeoil.json'
+encrypted_data_bag_secret_path = 'test/integration/encrypted_data_bag_secret'
+
+##
+# Run command wrapper
+def run_command(command)
+  if File.exist?('Gemfile.lock')
+    sh %(bundle exec #{command})
+  else
+    sh %(chef exec #{command})
+  end
+end
+
+##
+# Create a self-signed SSL certificate
+#
+def gen_ssl_cert
+  name = OpenSSL::X509::Name.new [
+    ['C', 'US'],
+    ['ST', 'Oregon'],
+    ['CN', 'OSU Open Source Lab'],
+    ['DC', 'example']
+  ]
+  key = OpenSSL::PKey::RSA.new 2048
+
+  cert = OpenSSL::X509::Certificate.new
+  cert.version = 2
+  cert.serial = 2
+  cert.subject = name
+  cert.public_key = key.public_key
+  cert.not_before = Time.now
+  cert.not_after = cert.not_before + 1 * 365 * 24 * 60 * 60 # 1 years validity
+
+  # Self-sign the Certificate
+  cert.issuer = name
+  cert.sign(key, OpenSSL::Digest::SHA1.new)
+
+  return cert, key
+end
+
+##
+# Create a data bag item (with the id of snakeoil) containing a self-signed SSL
+#  certificate
+#
+def ssl_data_bag_item
+  cert, key = gen_ssl_cert
+  Chef::DataBagItem.from_hash(
+    'id' => 'snakeoil',
+    'cert' => cert.to_pem,
+    'key' => key.to_pem
+  )
+end
+
+##
+# Create the integration tests directory if it doesn't exist
+#
+directory 'test/integration'
+
+##
+# Generates a 512 byte random sequence and write it to
+#  'test/integration/encrypted_data_bag_secret'
+#
+file encrypted_data_bag_secret_path => 'test/integration' do
+  encrypted_data_bag_secret = OpenSSL::Random.random_bytes(512)
+  open encrypted_data_bag_secret_path, 'w' do |io|
+    io.write Base64.encode64(encrypted_data_bag_secret)
+  end
+end
+
+##
+# Create the certificates data bag if it doesn't exist
+#
+directory 'test/integration/data_bags/certificates' => 'test/integration'
+
+##
+# Create the encrypted snakeoil certificate under
+#  test/integration/data_bags/certificates
+#
+file snakeoil_file_path => [
+  'test/integration/data_bags/certificates',
+  'test/integration/encrypted_data_bag_secret'
+] do
+
+  encrypted_data_bag_secret = Chef::EncryptedDataBagItem.load_secret(
+    encrypted_data_bag_secret_path
+  )
+
+  encrypted_snakeoil_cert = Chef::EncryptedDataBagItem.encrypt_data_bag_item(
+    ssl_data_bag_item, encrypted_data_bag_secret
+  )
+
+  open snakeoil_file_path, 'w' do |io|
+    io.write JSON.pretty_generate(encrypted_snakeoil_cert)
+  end
+end
+
+desc 'Create an Encrypted Databag Snakeoil SSL Certificate'
+task snakeoil: snakeoil_file_path
+
+desc 'Create an Encrypted Databag Secret'
+task secret_file: encrypted_data_bag_secret_path
+
+require 'rubocop/rake_task'
+desc 'Run RuboCop (style) tests'
+RuboCop::RakeTask.new(:style)
+
+desc 'Run FoodCritic (lint) tests'
+task :lint do
+    run_command('foodcritic --epic-fail any .')
+end
+
+desc 'Run RSpec (unit) tests'
+task :unit do
+    run_command('rspec')
+end
+
+desc 'Run all tests'
+task test: [:style, :lint, :unit]
+
+task default: :test

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-default['boulder']['revision'] = 'master'
+default['boulder']['revision'] = '2d33a9900cafe82993744fe73bd341fe47df2171'
 
 default['boulder']['config']['boulder-config']['va']['portConfig']['httpPort'] = 80
 default['boulder']['config']['boulder-config']['va']['portConfig']['httpsPort'] = 443

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@
 #
 
 default['boulder']['revision'] = '2d33a9900cafe82993744fe73bd341fe47df2171'
+default['boulder']['host_aliases'] = []
 
 default['boulder']['config']['boulder-config']['va']['portConfig']['httpPort'] = 80
 default['boulder']['config']['boulder-config']['va']['portConfig']['httpsPort'] = 443

--- a/chefignore
+++ b/chefignore
@@ -1,5 +1,5 @@
 # Put files/directories that should be ignored in this file when uploading
-# or sharing to the community site.
+# to a chef-server or supermarket.
 # Lines that start with '# ' are comments.
 
 # OS generated files #
@@ -51,8 +51,16 @@ spec/*
 spec/fixtures/*
 test/*
 features/*
+examples/*
 Guardfile
 Procfile
+.kitchen*
+.rubocop.yml
+spec/*
+Rakefile
+.travis.yml
+.foodcritic
+.codeclimate.yml
 
 # SCM #
 #######
@@ -69,13 +77,22 @@ Procfile
 
 # Berkshelf #
 #############
+Berksfile
+Berksfile.lock
 cookbooks/*
 tmp
 
+# Policyfile #
+##############
+Policyfile.rb
+Policyfile.lock.json
+
 # Cookbooks #
 #############
-CONTRIBUTING
+CONTRIBUTING*
 CHANGELOG*
+TESTING*
+MAINTAINERS.toml
 
 # Strainer #
 ############
@@ -88,11 +105,3 @@ Strainerfile
 ###########
 .vagrant
 Vagrantfile
-
-# Travis #
-##########
-.travis.yml
-
-# Test-Kitchen #
-################
-.kitchen

--- a/files/default/setup.sh
+++ b/files/default/setup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Fetch dependencies of Boulder that are necessary for development or testing,
+# and configure database and RabbitMQ.
+#
+
+set -ev
+
+go get \
+  bitbucket.org/liamstask/goose/cmd/goose \
+  github.com/golang/lint/golint \
+  github.com/golang/mock/mockgen \
+  github.com/golang/protobuf/proto \
+  github.com/golang/protobuf/protoc-gen-go \
+  github.com/jsha/listenbuddy \
+  github.com/kisielk/errcheck \
+  github.com/mattn/goveralls \
+  github.com/modocache/gover \
+  github.com/tools/godep \
+  golang.org/x/tools/cmd/stringer \
+  golang.org/x/tools/cover &
+
+(curl -sL https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz | \
+ tar -xzv &&
+ cd protobuf-2.6.1 && ./configure --prefix=$HOME && make && make install) &
+
+# Set up rabbitmq exchange
+go run cmd/rabbitmq-setup/main.go -server amqp://boulder-rabbitmq &
+
+# Wait for all the background commands to finish.
+wait
+
+# Create the database and roles
+./test/create_db.sh

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,11 +1,11 @@
 name             'osl-letsencrypt-boulder-server'
-maintainer       'Thijs Houtenbos'
-maintainer_email 'thoutenbos@schubergphilis.com'
-license          'All rights reserved'
+maintainer       'Oregon State University'
+maintainer_email 'chef@osuosl.org'
+license          'apachev2'
 description      "Installs/Configures Boulder, the ACME-based CA server by Let's Encrypt."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-issues_url       'https://github.com/patcon/chef-letsencrypt-boulder-server/issues'
-source_url       'https://github.com/patcon/chef-letsencrypt-boulder-server'
+issues_url       'https://github.com/osuosl-cookbooks/osl-letsencrypt-boulder-server/issues'
+source_url       'https://github.com/osuosl-cookbooks/osl-letsencrypt-boulder-server'
 version          '0.1.2'
 
 supports         'centos', '~> 6.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-name             'letsencrypt-boulder-server'
+name             'osl-letsencrypt-boulder-server'
 maintainer       'Thijs Houtenbos'
 maintainer_email 'thoutenbos@schubergphilis.com'
 license          'All rights reserved'
@@ -8,12 +8,13 @@ issues_url       'https://github.com/patcon/chef-letsencrypt-boulder-server/issu
 source_url       'https://github.com/patcon/chef-letsencrypt-boulder-server'
 version          '0.1.2'
 
-supports         'ubuntu', '= 14.04'
-supports         'centos', '~> 7'
+supports         'centos', '~> 6.0'
+supports         'centos', '~> 7.0'
 
 depends          'golang'
 depends          'rabbitmq'
 depends          'mariadb'
 depends          'build-essential'
+depends          'poise-python'
 depends          'yum'
 depends          'hostsfile'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -55,7 +55,7 @@ end
 
 hostsfile_entry '127.0.0.1' do
   hostname 'localhost'
-  aliases ['boulder', 'boulder-rabbitmq', 'boulder-mysql']
+  aliases ['boulder', 'boulder-rabbitmq', 'boulder-mysql'] + node['boulder']['host_aliases']
   action :create
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,23 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+ChefSpec::Coverage.start! { add_filter 'osl-letsencrypt-boulder-server' }
+
+CENTOS_7 = {
+  platform: 'centos',
+  version: '7.2.1511'
+}.freeze
+
+CENTOS_6 = {
+  platform: 'centos',
+  version: '6.7'
+}.freeze
+
+ALL_PLATFORMS = [
+  CENTOS_6,
+  CENTOS_7
+].freeze
+
+RSpec.configure do |config|
+  config.log_level = :fatal
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,111 @@
+require_relative '../../spec_helper'
+
+describe 'osl-letsencrypt-boulder-server::default' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+      before do
+        stub_command('/usr/local/go/bin/go version | grep "go1.5 "')
+        stub_command('screen -list boulder | /bin/grep 1\ Socket\ in')
+      end
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+      %w(
+        git
+        screen
+        initscripts
+        logrotate
+        tar
+        wget
+        libtool-ltdl-devel
+      ).each do |pkg|
+        it do
+          expect(chef_run).to install_package(pkg)
+        end
+      end
+      it do
+        expect(chef_run).to install_chef_gem('rest-client').with(compile_time: false)
+      end
+      it do
+        expect(chef_run).to create_hostsfile_entry('127.0.0.1')
+          .with(
+            hostname: 'localhost',
+            aliases: %w(boulder boulder-rabbitmq boulder-mysql)
+          )
+      end
+      context 'Set host_aliases' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.set['boulder']['host_aliases'] = %w(foo.example.org bar.example.org)
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to create_hostsfile_entry('127.0.0.1')
+            .with(
+              hostname: 'localhost',
+              aliases: %w(boulder boulder-rabbitmq boulder-mysql foo.example.org bar.example.org)
+            )
+        end
+      end
+      it do
+        expect(chef_run).to create_directory('/opt/go/src/github.com/letsencrypt')
+          .with(recursive: true)
+      end
+      it do
+        expect(chef_run).to checkout_git('/opt/go/src/github.com/letsencrypt/boulder')
+          .with(
+            repository: 'https://github.com/letsencrypt/boulder',
+            revision: '2d33a9900cafe82993744fe73bd341fe47df2171'
+          )
+      end
+      it do
+        expect(chef_run).to create_cookbook_file('/opt/go/src/github.com/letsencrypt/boulder/test/setup.sh')
+          .with(mode: 0755)
+      end
+      %w(boulder_config boulder_limit wait_for_bootstrap).each do |rb|
+        it do
+          expect(chef_run).to run_ruby_block(rb)
+        end
+      end
+      it do
+        expect(chef_run).to run_bash('boulder_setup')
+          .with(
+            live_stream: true,
+            cwd: '/opt/go/src/github.com/letsencrypt/boulder',
+            code: 'source /etc/profile.d/golang.sh && GO15VENDOREXPERIMENT=1 ./test/setup.sh 2>&1 && touch setup.done',
+            creates: '/opt/go/src/github.com/letsencrypt/boulder/setup.done'
+          )
+      end
+      case p
+      when CENTOS_6
+        it do
+          expect(chef_run).to install_python_runtime('2.7')
+        end
+        it do
+          expect(chef_run).to run_bash('run_boulder')
+            .with(
+              live_stream: true,
+              cwd: '/opt/go/src/github.com/letsencrypt/boulder',
+              code: 'source /etc/profile.d/golang.sh && GO15VENDOREXPERIMENT=1 screen -LdmS boulder ' \
+                    'scl enable python27 ./start.py'
+            )
+        end
+      when CENTOS_7
+        it do
+          expect(chef_run).to_not install_python_runtime('2.7')
+        end
+        it do
+          expect(chef_run).to run_bash('run_boulder')
+            .with(
+              live_stream: true,
+              cwd: '/opt/go/src/github.com/letsencrypt/boulder',
+              code: 'source /etc/profile.d/golang.sh && GO15VENDOREXPERIMENT=1 screen -LdmS boulder  ./start.py'
+            )
+        end
+      end
+    end
+  end
+end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -1,0 +1,7 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe command('curl http://127.0.0.1:4000/directory') do
+  its(:stdout) { should match(%r{"new-cert": "http://127.0.0.1:4000/acme/new-cert"}) }
+end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -2,6 +2,6 @@ require 'serverspec'
 
 set :backend, :exec
 
-describe command('curl http://127.0.0.1:4000/directory') do
+describe command('curl http://boulder:4000/directory') do
   its(:stdout) { should match(%r{"new-cert": "http://127.0.0.1:4000/acme/new-cert"}) }
 end

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -1,0 +1,6 @@
+# # encoding: utf-8
+
+# Inspec test for recipe osl-letsencrypt-boulder-server::default
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at http://inspec.io/docs/reference/resources/


### PR DESCRIPTION
This does some basic cleanup and adds support for running on CentOS 6. In
addition it does the following:

- Installs Python 2.7 from SCL on CentOS 6
- Uses an updated setup.sh which builds goose instead of pulling from a pre-built
  binary which is incompatible on CentOS 6 systems
- Use "scl enable python27" to run the service when on CentOS 6
- Lock to a revision which is known to work
- Add some basic test-kitchen configuration which works at the OSL