### PR TITLE
Upgrade go version to 1.7

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,6 +34,7 @@ end
 
 node.default['mariadb']['use_default_repository'] = true
 node.default['mariadb']['install']['version'] = '10.1'
+node.default['go']['version'] = '1.7'
 
 include_recipe 'build-essential'
 include_recipe 'mariadb::server'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -7,7 +7,7 @@ describe 'osl-letsencrypt-boulder-server::default' do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
       before do
-        stub_command('/usr/local/go/bin/go version | grep "go1.5 "')
+        stub_command('/usr/local/go/bin/go version | grep "go1.7 "')
         stub_command('screen -list boulder | /bin/grep 1\ Socket\ in')
       end
       it 'converges successfully' do

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -5,3 +5,7 @@ set :backend, :exec
 describe command('curl http://boulder:4000/directory') do
   its(:stdout) { should match(%r{"new-cert": "http://127.0.0.1:4000/acme/new-cert"}) }
 end
+
+describe command('/usr/local/go/bin/go version') do
+  its(:stdout) { should match(/go1\.7/) }
+end


### PR DESCRIPTION
Boulder needs the goose plugin to function, which requires the go-sql-driver,
which no longer supports go =< 1.6 [1] (golang cookbook sets it to 1.5 by default). This causes the boulder cookbook to fail.

[1] https://github.com/go-sql-driver/mysql/pull/696