### PR TITLE
Switch to using go-1.8 on legacy setup

### DIFF
--- a/recipes/_legacy.rb
+++ b/recipes/_legacy.rb
@@ -2,7 +2,7 @@ package %w(screen initscripts logrotate tar wget libtool-ltdl-devel)
 
 node.default['mariadb']['use_default_repository'] = true
 node.default['mariadb']['install']['version'] = '10.1'
-node.default['go']['version'] = '1.7'
+node.default['go']['version'] = '1.8'
 
 include_recipe 'mariadb::server'
 include_recipe 'rabbitmq'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -10,7 +10,7 @@ describe 'osl-letsencrypt-boulder-server::default' do
       end
       before do
         stub_command('/usr/local/bin/docker-compose ps -q | wc -l | grep 0').and_return(true)
-        stub_command('/usr/local/go/bin/go version | grep "go1.7 "')
+        stub_command('/usr/local/go/bin/go version | grep "go1.8 "')
         stub_command('screen -list boulder | /bin/grep 1\ Socket\ in')
       end
       it 'converges successfully' do


### PR DESCRIPTION
The "goose" go binary fails to build due to the fail that it now requires go-1.8
and above. This should fix issues running this on CentOS 6.