### PR TITLE
Add advanced host aliases, fix template

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 default['boulder']['host_aliases'] = []
+default['boulder']['host_aliases_advanced'] = {}
 if node['platform_version'].to_i >= 7
   default['boulder']['dir'] = '/opt/boulder'
   default['boulder']['revision'] = 'release-2018-02-13'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,11 +23,13 @@ template '/etc/dnsmasq.conf' do
   source 'dnsmasq.erb'
   if node['platform_version'].to_i == 6
     variables(
-      hosts: %w(boulder boulder-rabbitmq boulder-mysql) + node['boulder']['host_aliases']
+      hosts: %w(boulder boulder-rabbitmq boulder-mysql) + node['boulder']['host_aliases'],
+      hosts_advanced: node['boulder']['host_aliases_advanced']
     )
   else
     variables(
-      hosts: node['boulder']['host_aliases']
+      hosts: node['boulder']['host_aliases'],
+      hosts_advanced: node['boulder']['host_aliases_advanced']
     )
   end
   notifies :restart, 'service[dnsmasq]', :immediately

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -6,6 +6,10 @@ describe 'osl-letsencrypt-boulder-server::default' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p) do |node|
           node.set['boulder']['host_aliases'] = %w(example.com foo.org)
+          node.set['boulder']['host_aliases_advanced'] = {
+            'new.com' => '10.0.0.3',
+            'another.org' => '10.0.0.4'
+          }
         end.converge(described_recipe)
       end
       before do
@@ -26,6 +30,12 @@ describe 'osl-letsencrypt-boulder-server::default' do
         it do
           expect(chef_run).to render_file('/etc/dnsmasq.conf').with_content(%r{^address=/#{host}/10.0.0.2$})
         end
+      end
+      it do
+        expect(chef_run).to render_file('/etc/dnsmasq.conf').with_content(%r{^address=/new.com/10.0.0.3$})
+      end
+      it do
+        expect(chef_run).to render_file('/etc/dnsmasq.conf').with_content(%r{^address=/another.org/10.0.0.4$})
       end
       it do
         expect(chef_run.template('/etc/dnsmasq.conf')).to notify('service[dnsmasq]').to(:restart).immediately
@@ -52,8 +62,14 @@ describe 'osl-letsencrypt-boulder-server::default' do
       when CENTOS_7
         %w(boulder boulder-rabbitmq boulder-mysql).each do |host|
           it do
-            expect(chef_run).to_not render_file('/etc/dnsmasq.conf').with_content(%r{^address=/#{host}/127.0.0.1$})
+            expect(chef_run).to_not render_file('/etc/dnsmasq.conf').with_content(%r{^address=/#{host}/10.0.0.2$})
           end
+        end
+        it do
+          expect(chef_run).to render_file('/etc/dnsmasq.conf').with_content(%r{^address=/new.com/10.0.0.3$})
+        end
+        it do
+          expect(chef_run).to render_file('/etc/dnsmasq.conf').with_content(%r{^address=/another.org/10.0.0.4$})
         end
         it do
           expect(chef_run).to create_directory('/opt/boulder')
@@ -83,8 +99,14 @@ describe 'osl-letsencrypt-boulder-server::default' do
       when CENTOS_6
         %w(boulder boulder-rabbitmq boulder-mysql).each do |host|
           it do
-            expect(chef_run).to render_file('/etc/dnsmasq.conf').with_content(%r{^address=/#{host}/127.0.0.1$})
+            expect(chef_run).to render_file('/etc/dnsmasq.conf').with_content(%r{^address=/#{host}/10.0.0.2$})
           end
+        end
+        it do
+          expect(chef_run).to render_file('/etc/dnsmasq.conf').with_content(%r{^address=/new.com/10.0.0.3$})
+        end
+        it do
+          expect(chef_run).to render_file('/etc/dnsmasq.conf').with_content(%r{^address=/another.org/10.0.0.4$})
         end
         it do
           expect(chef_run).to create_directory('/opt/go/src/github.com/letsencrypt/boulder')

--- a/templates/default/dnsmasq.erb
+++ b/templates/default/dnsmasq.erb
@@ -1,10 +1,8 @@
-<% node['boulder']['host_aliases'].each do |host| -%>
+<% @hosts.each do |host| -%>
 address=/<%= host %>/<%= node['ipaddress'] %>
 <% end -%>
-<% if node['platform_version'].to_i == 6 %>
-address=/boulder/127.0.0.1
-address=/boulder-rabbitmq/127.0.0.1
-address=/boulder-mysql/127.0.0.1
+<% @hosts_advanced.each do |host, ip| -%>
+address=/<%= host %>/<%= ip %>
 <% end -%>
 no-resolv
 server=140.211.166.130


### PR DESCRIPTION
This adds a new attribute called `host_aliases_advanced`, which takes a hash of `host: ip` pairs. This also fixes an issue I saw in the template file (We were passing variables but not using them!), as well as simplifying some CentOS 6 specific code.