### PR TITLE
Update boulder version

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,11 @@
 ---
 driver:
   flavor_ref: 'm1.medium'
+  attributes:
+    yum:
+      epel:
+        baseurl: http://epel.osuosl.org/7/$basearch
+        gpgkey: http://epel.osuosl.org/RPM-GPG-KEY-EPEL-7
 
 suites:
   - name: default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 #
 default['boulder']['host_aliases'] = []
 default['boulder']['dir'] = '/opt/boulder'
-default['boulder']['revision'] = 'release-2018-02-13'
+default['boulder']['revision'] = 'release-2018-08-27'
 default['boulder']['config']['va']['va']['portConfig']['httpPort'] = 80
 default['boulder']['config']['va']['va']['portConfig']['httpsPort'] = 443
 default['boulder']['config']['va']['va']['portConfig']['tlsPort'] = 443

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -107,7 +107,7 @@ ruby_block 'wait_for_bootstrap' do
         client = RestClient.get 'http://127.0.0.1:4000/directory'
       rescue
         sleep 10
-        puts "Still waiting for boulder to start.. #{times * 10} seconds"
+        print "\nStill waiting for boulder to start.. #{times * 10} seconds"
       end
       Chef::Application.fatal!('Failed to run boulder server') if times > 30
       break if client && client.code == 200

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -67,7 +67,7 @@ describe 'osl-letsencrypt-boulder-server::default' do
         expect(chef_run).to checkout_git('/opt/boulder')
           .with(
             repository: 'https://github.com/letsencrypt/boulder',
-            revision: 'release-2018-02-13'
+            revision: 'release-2018-08-27'
           )
       end
       it do


### PR DESCRIPTION
Using the newest version of boulder will help keep the production and testing boulder software as similar as possible, and possibly fix bugs / increase performance.

I've also tested this against `osl-haproxy`, all tests pass. 

More changes:
* Use our EPEL repo
* Fix boulder wait loop printing