### PR TITLE
Update boulder to revision release-2019-10-28

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 #
 default['boulder']['host_aliases'] = []
 default['boulder']['dir'] = '/opt/boulder'
-default['boulder']['revision'] = 'release-2018-08-27'
+default['boulder']['revision'] = 'release-2019-10-28'
 default['boulder']['config']['va']['va']['portConfig']['httpPort'] = 80
 default['boulder']['config']['va']['va']['portConfig']['httpsPort'] = 443
 default['boulder']['config']['va']['va']['portConfig']['tlsPort'] = 443

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -67,7 +67,7 @@ describe 'osl-letsencrypt-boulder-server::default' do
         expect(chef_run).to checkout_git('/opt/boulder')
           .with(
             repository: 'https://github.com/letsencrypt/boulder',
-            revision: 'release-2018-08-27'
+            revision: 'release-2019-10-28'
           )
       end
       it do

--- a/test/cookbooks/boulder_test/recipes/default.rb
+++ b/test/cookbooks/boulder_test/recipes/default.rb
@@ -1,4 +1,4 @@
-node.default['acme']['endpoint'] = 'http://127.0.0.1:4000'
+node.default['acme']['dir'] = 'http://127.0.0.1:4001/directory'
 include_recipe 'osl-acme'
 include_recipe 'osl-apache'
 include_recipe 'apache2::mod_ssl'

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,5 +1,5 @@
-describe http('http://localhost:4000/directory', enable_remote_worker: true) do
-  its('body') { should match(%r{"new-cert": "http://(localhost|127.0.0.1):4000/acme/new-cert"}) }
+describe http('http://localhost:4001/directory', enable_remote_worker: true) do
+  its('body') { should match(%r{"newAccount": "http://(localhost|127.0.0.1):4001/acme/new-acct"}) }
 end
 
 describe command('curl https://foo.org -k -v') do


### PR DESCRIPTION
In addition, update test cookbook to use V2 endpoints and also update acme
cookbook attributes to match newer cookbook attributes.